### PR TITLE
encode login variable so usernames with special chars such as @ wont …

### DIFF
--- a/src/main/java/org/jahia/modules/downloadhelper/services/DownloadHelperService.java
+++ b/src/main/java/org/jahia/modules/downloadhelper/services/DownloadHelperService.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -82,7 +83,8 @@ public final class DownloadHelperService {
                 if (LOGGER.isInfoEnabled()) {
                     LOGGER.info(String.format("Download of %s to %s asked by %s from %s", completeUrl, filename, user, ip));
                 }
-                final String ftpUrl = String.format("ftp://%s:%s@%s", login, password, url);
+                final String encodedLogin = URLEncoder.encode(login, StandardCharsets.UTF_8.toString());
+                final String ftpUrl = String.format("ftp://%s:%s@%s", encodedLogin, password, url);
                 final URLConnection urlConnection = new URL(ftpUrl).openConnection();
                 inputStream = urlConnection.getInputStream();
                 Files.copy(


### PR DESCRIPTION
…create a bad url

current download helper will fail when trying to create an ftp url to download when using a user id such as jahia usually provisions to ftp e.g. myuser@jahia.com.  Encoding the login value fixes this issue.

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/PROJECT-XXX

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [x] Migration
- [x] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
