### PR TITLE
security: harden HTTPS download against redirect-based SSRF and log injection (SECURITY-746)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,28 @@ yarn install
 - **Chunked-transfer DoS**: when `Content-Length <= 0`, download is now capped at currently-available disk space and aborted if exceeded (previously the size check was skipped entirely).
 - **Thread safety**: `SimpleDateFormat` is instantiated per call via `formatNow()` rather than shared across raw download threads (also avoids ThreadLocal classloader leaks in OSGi).
 
+## Security invariants (do not regress) — SECURITY-746
+
+The SSRF and log-injection predicates live in `org.jahia.modules.downloadhelper.util.UrlSecurityUtils`
+(pure, no DNS/OSGi, fully unit-tested). Do not duplicate them inline — extend the helper instead.
+
+- **No automatic redirect following on the HTTPS download.** `downloadHttps` follows redirects manually
+  in a loop bounded by `UrlSecurityUtils.maxRedirects()` (5). Every hop is re-validated with
+  `assertSafeHost`, so a `302 → http://169.254.169.254/` (or any internal/site-local host) is rejected
+  *before* the connect, not after the SSRF guard has already been passed.
+- **Basic credentials never follow a cross-host redirect.** The `Authorization` header is only added
+  when `UrlSecurityUtils.sameHost(currentUrl, initialUrl)` — admin-supplied credentials cannot leak
+  to a redirect target.
+- **Only `http`/`https` redirect schemes are honored.** `file:`, `ftp:`, `gopher:`, `jar:` etc. in a
+  `Location` header are rejected (`UrlSecurityUtils.isAllowedHttpScheme`).
+- **All user-controlled values are sanitized before logging.** Both the service and the mutation
+  extension route through `UrlSecurityUtils.sanitizeForLog` — log-injection is closed in *every* code
+  path that logs `url` / `filename` / `user`, including the async failure catch in the mutation.
+- **Accepted residual: DNS-rebinding TOCTOU.** `assertSafeHost` resolves DNS, then the HTTP client
+  re-resolves at connect time. Fully closing this requires IP pinning via a custom connection manager;
+  given the `adminSystemInfos` permission gate it is documented as an accepted residual rather than
+  fixed.
+
 ## Gotchas
 
 - Download runs in a raw `new Thread()` — no thread pool, no cancellation; long downloads tie up a JVM thread

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,18 @@
       <version>3.4.0</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.25.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperMutationExtension.java
+++ b/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperMutationExtension.java
@@ -3,6 +3,7 @@ package org.jahia.modules.downloadhelper.graphql;
 import graphql.annotations.annotationTypes.*;
 import org.apache.commons.io.FilenameUtils;
 import org.jahia.modules.downloadhelper.services.DownloadHelperService;
+import org.jahia.modules.downloadhelper.util.UrlSecurityUtils;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
 import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 import org.jahia.osgi.BundleUtils;
@@ -48,7 +49,10 @@ public class DownloadHelperMutationExtension {
             try {
                 service.download(protocol, url, login, password, filename, email, currentUser);
             } catch (IOException e) {
-                LOGGER.error("Async download failed for url={} filename={} user={}", url, filename, currentUser, e);
+                LOGGER.error("Async download failed for url={} filename={} user={}",
+                        UrlSecurityUtils.sanitizeForLog(url),
+                        UrlSecurityUtils.sanitizeForLog(filename),
+                        UrlSecurityUtils.sanitizeForLog(currentUser), e);
             }
         }).start();
 

--- a/src/main/java/org/jahia/modules/downloadhelper/services/DownloadHelperService.java
+++ b/src/main/java/org/jahia/modules/downloadhelper/services/DownloadHelperService.java
@@ -3,11 +3,14 @@ package org.jahia.modules.downloadhelper.services;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.net.util.Base64;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpStatus;
 import org.jahia.modules.downloadhelper.constants.Email;
+import org.jahia.modules.downloadhelper.util.UrlSecurityUtils;
 import org.jahia.services.mail.MailService;
 import org.jahia.services.notification.HttpClientService;
 import org.osgi.service.component.annotations.Activate;
@@ -32,10 +35,9 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
+
+import static org.jahia.modules.downloadhelper.util.UrlSecurityUtils.sanitizeForLog;
 
 @Component(service = DownloadHelperService.class)
 public class DownloadHelperService {
@@ -45,15 +47,6 @@ public class DownloadHelperService {
     private static final int KILO_CONSTANT = 1024;
     private static final String MSG_COULD_NOT_CREATE_FOLDER = "Could not create download folder: {}";
     private static final String DATE_PATTERN = "yyyy/MM/dd 'at' HH:mm:ss z";
-
-    /**
-     * Cloud metadata / well-known SSRF target hostnames that must never be reachable
-     * even from an admin-triggered download.
-     */
-    private static final Set<String> BLOCKED_HOSTS = new HashSet<>(Arrays.asList(
-            "metadata.google.internal",
-            "metadata.goog",
-            "metadata"));
 
     /**
      * SimpleDateFormat is not thread-safe; downloads run in separate threads, so we build a fresh
@@ -81,26 +74,17 @@ public class DownloadHelperService {
     }
 
     /**
-     * Strips CR/LF from a string so attacker-controlled input cannot forge log lines.
-     */
-    private static String sanitizeForLog(String value) {
-        if (value == null) {
-            return null;
-        }
-        return value.replace('\n', '_').replace('\r', '_');
-    }
-
-    /**
-     * Rejects URLs that resolve to loopback, link-local, site-local, any-local, multicast addresses
-     * or to well-known cloud-metadata hostnames. Defense-in-depth against SSRF even though the
-     * caller already requires the {@code adminSystemInfos} permission.
+     * Rejects URLs that resolve to loopback, link-local, site-local, any-local, multicast addresses,
+     * the cloud-metadata IP, or well-known cloud-metadata hostnames. Defense-in-depth against SSRF
+     * even though the caller already requires the {@code adminSystemInfos} permission. The classification
+     * predicates live in {@link UrlSecurityUtils} so they can be unit-tested without DNS.
      */
     private static void assertSafeHost(String host) throws IOException {
         if (host == null || host.isEmpty()) {
             throw new IOException("Empty host is not allowed");
         }
         final String lowerHost = host.toLowerCase();
-        if (BLOCKED_HOSTS.contains(lowerHost)) {
+        if (UrlSecurityUtils.isBlockedHost(host)) {
             throw new IOException("Host is blocked: " + lowerHost);
         }
         final InetAddress[] addresses;
@@ -110,17 +94,8 @@ public class DownloadHelperService {
             throw new IOException("Unknown host: " + lowerHost, e);
         }
         for (InetAddress address : addresses) {
-            if (address.isAnyLocalAddress()
-                    || address.isLoopbackAddress()
-                    || address.isLinkLocalAddress()
-                    || address.isSiteLocalAddress()
-                    || address.isMulticastAddress()) {
-                throw new IOException("Host resolves to a non-routable / private address: " + lowerHost);
-            }
-            // 169.254.169.254 (AWS / Azure / OpenStack metadata) is link-local and already blocked above,
-            // but also reject the canonical address explicitly for clarity.
-            if ("169.254.169.254".equals(address.getHostAddress())) {
-                throw new IOException("Cloud metadata endpoint is blocked: " + lowerHost);
+            if (UrlSecurityUtils.isNonRoutableAddress(address)) {
+                throw new IOException("Host resolves to a non-routable / blocked address: " + lowerHost);
             }
         }
     }
@@ -181,40 +156,74 @@ public class DownloadHelperService {
 
     private boolean downloadHttps(String url, String login, String password, String filename,
             String ccEmail, String user, File targetFile) throws IOException {
-        final String completeUrl = "https://" + url;
-        assertSafeHost(extractHost(completeUrl));
+        final String initialUrl = "https://" + url;
+        assertSafeHost(extractHost(initialUrl));
         sendEmail(url, filename, ccEmail, user, Email.DOWNLOAD_ASKED_SUBJECT);
         if (LOGGER.isInfoEnabled()) {
             LOGGER.info("Download of {} to {} asked by {}",
-                    sanitizeForLog(completeUrl), sanitizeForLog(filename), sanitizeForLog(user));
+                    sanitizeForLog(initialUrl), sanitizeForLog(filename), sanitizeForLog(user));
         }
 
-        final CloseableHttpClient httpClient = httpClientService.getHttpClient(completeUrl);
-        final HttpGet httpGet = new HttpGet(completeUrl);
-        if (login != null && !login.isEmpty() && password != null && !password.isEmpty()) {
-            httpGet.addHeader("Authorization", "Basic " + new String(
-                    Base64.encodeBase64((login + ":" + password).getBytes(StandardCharsets.UTF_8)),
-                    StandardCharsets.UTF_8));
-        }
+        final CloseableHttpClient httpClient = httpClientService.getHttpClient(initialUrl);
+        String currentUrl = initialUrl;
+        // The shared HttpClient follows redirects automatically, which would let a remote server
+        // 30x-redirect to an internal / metadata host and bypass assertSafeHost (and replay the
+        // Basic credentials to it). We disable automatic redirects and follow them ourselves,
+        // re-validating every hop and only sending credentials to the originally validated host.
+        for (int hop = 0; hop <= UrlSecurityUtils.maxRedirects(); hop++) {
+            assertSafeHost(extractHost(currentUrl));
+            final HttpGet httpGet = new HttpGet(currentUrl);
+            httpGet.setConfig(RequestConfig.custom().setRedirectsEnabled(false).build());
+            if (UrlSecurityUtils.sameHost(currentUrl, initialUrl)
+                    && login != null && !login.isEmpty() && password != null && !password.isEmpty()) {
+                httpGet.addHeader("Authorization", "Basic " + new String(
+                        Base64.encodeBase64((login + ":" + password).getBytes(StandardCharsets.UTF_8)),
+                        StandardCharsets.UTF_8));
+            }
+            httpGet.addHeader(org.apache.http.HttpHeaders.USER_AGENT, "Jahia - Download Helper");
 
-        httpGet.addHeader(org.apache.http.HttpHeaders.USER_AGENT, "Jahia - Download Helper");
-        try (CloseableHttpResponse httpResponse = httpClient.execute(httpGet)) {
-            final HttpEntity entity = httpResponse.getEntity();
-            if (entity != null && HttpStatus.SC_OK == httpResponse.getCode()) {
-                if (!hasEnoughSpace(entity.getContentLength(), url, filename, ccEmail, user)) {
-                    return false;
+            try (CloseableHttpResponse httpResponse = httpClient.execute(httpGet)) {
+                final int statusCode = httpResponse.getCode();
+                if (UrlSecurityUtils.isRedirectStatus(statusCode)) {
+                    currentUrl = nextRedirectUrl(currentUrl, httpResponse);
+                    continue;
                 }
 
-                copyWithLimit(entity.getContent(), targetFile, entity.getContentLength());
-                return true;
-            }
+                final HttpEntity entity = httpResponse.getEntity();
+                if (entity != null && HttpStatus.SC_OK == statusCode) {
+                    if (!hasEnoughSpace(entity.getContentLength(), url, filename, ccEmail, user)) {
+                        return false;
+                    }
 
-            if (LOGGER.isInfoEnabled()) {
-                LOGGER.info("Download of {} to {} asked by {} has failed",
-                        sanitizeForLog(completeUrl), sanitizeForLog(filename), sanitizeForLog(user));
+                    copyWithLimit(entity.getContent(), targetFile, entity.getContentLength());
+                    return true;
+                }
+
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info("Download of {} to {} asked by {} has failed with status {}",
+                            sanitizeForLog(currentUrl), sanitizeForLog(filename), sanitizeForLog(user), statusCode);
+                }
+                return false;
             }
-            return false;
         }
+
+        throw new IOException("Too many redirects (max " + UrlSecurityUtils.maxRedirects() + ")");
+    }
+
+    /**
+     * Resolves and validates the {@code Location} of a redirect response. Only absolute http(s)
+     * targets are honored; the returned URL still gets {@code assertSafeHost}-checked on the next loop hop.
+     */
+    private static String nextRedirectUrl(String currentUrl, CloseableHttpResponse response) throws IOException {
+        final Header locationHeader = response.getFirstHeader("Location");
+        if (locationHeader == null) {
+            throw new IOException("Redirect response without a Location header");
+        }
+        final String resolved = UrlSecurityUtils.resolveLocation(currentUrl, locationHeader.getValue());
+        if (resolved == null || !UrlSecurityUtils.isAllowedHttpScheme(resolved)) {
+            throw new IOException("Refusing to follow redirect to a non-http(s) or unparsable location");
+        }
+        return resolved;
     }
 
     private boolean downloadFtp(String url, String login, String password, String filename,

--- a/src/main/java/org/jahia/modules/downloadhelper/util/UrlSecurityUtils.java
+++ b/src/main/java/org/jahia/modules/downloadhelper/util/UrlSecurityUtils.java
@@ -1,0 +1,146 @@
+package org.jahia.modules.downloadhelper.util;
+
+import org.apache.hc.core5.http.HttpStatus;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Pure, side-effect-free helpers backing the download SSRF / log-injection defenses.
+ *
+ * <p>Everything here is deterministic and free of JCR / OSGi / network access (the one method that
+ * inspects an {@link InetAddress} accepts an already-resolved address), so it can be unit-tested in
+ * isolation. Keeping the security-critical predicates in one tested place avoids the
+ * "check-then-trust" drift that the redirect-based SSRF bypass exploited.</p>
+ */
+public final class UrlSecurityUtils {
+
+    /**
+     * Cloud-metadata / well-known SSRF target hostnames that must never be reachable,
+     * even from an admin-triggered download.
+     */
+    private static final Set<String> BLOCKED_HOSTS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            "metadata.google.internal",
+            "metadata.goog",
+            "metadata")));
+
+    private static final String CLOUD_METADATA_IP = "169.254.169.254";
+    private static final int MAX_REDIRECTS = 5;
+
+    private UrlSecurityUtils() {
+    }
+
+    public static int maxRedirects() {
+        return MAX_REDIRECTS;
+    }
+
+    /**
+     * Strips CR/LF from a string so attacker-controlled input cannot forge log lines (CWE-117).
+     */
+    public static String sanitizeForLog(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replace('\n', '_').replace('\r', '_');
+    }
+
+    /**
+     * @return {@code true} when the host (case-insensitively) is a well-known cloud-metadata hostname.
+     */
+    public static boolean isBlockedHost(String host) {
+        if (host == null || host.isEmpty()) {
+            return true;
+        }
+        return BLOCKED_HOSTS.contains(host.toLowerCase());
+    }
+
+    /**
+     * @return {@code true} when the resolved address is loopback, link-local, site-local, any-local,
+     * multicast, or the canonical cloud-metadata IP — i.e. must never be contacted.
+     */
+    public static boolean isNonRoutableAddress(InetAddress address) {
+        if (address == null) {
+            return true;
+        }
+        return address.isAnyLocalAddress()
+                || address.isLoopbackAddress()
+                || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress()
+                || address.isMulticastAddress()
+                || CLOUD_METADATA_IP.equals(address.getHostAddress());
+    }
+
+    /**
+     * @return {@code true} for the HTTP status codes that carry a {@code Location} redirect.
+     */
+    public static boolean isRedirectStatus(int statusCode) {
+        return statusCode == HttpStatus.SC_MOVED_PERMANENTLY
+                || statusCode == HttpStatus.SC_MOVED_TEMPORARILY
+                || statusCode == HttpStatus.SC_SEE_OTHER
+                || statusCode == HttpStatus.SC_TEMPORARY_REDIRECT
+                || statusCode == HttpStatus.SC_PERMANENT_REDIRECT;
+    }
+
+    /**
+     * Only {@code http}/{@code https} redirect targets are honored; {@code file:}, {@code ftp:},
+     * {@code gopher:}, {@code jar:} etc. are rejected to keep the SSRF surface closed.
+     */
+    public static boolean isAllowedHttpScheme(String url) {
+        final String scheme = schemeOf(url);
+        return "http".equals(scheme) || "https".equals(scheme);
+    }
+
+    /**
+     * Resolves a (possibly relative) {@code Location} header against the current absolute URL.
+     *
+     * @return the absolute redirect target, or {@code null} if it cannot be parsed.
+     */
+    public static String resolveLocation(String currentUrl, String location) {
+        if (currentUrl == null || location == null || location.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return new URI(currentUrl).resolve(location.trim()).toString();
+        } catch (IllegalArgumentException | URISyntaxException e) {
+            return null;
+        }
+    }
+
+    /**
+     * @return {@code true} only when both URLs parse to the same (case-insensitive) host. Used to
+     * decide whether the {@code Authorization} header may be replayed on a redirect.
+     */
+    public static boolean sameHost(String urlA, String urlB) {
+        final String hostA = hostOf(urlA);
+        final String hostB = hostOf(urlB);
+        return hostA != null && hostA.equalsIgnoreCase(hostB);
+    }
+
+    public static String hostOf(String url) {
+        if (url == null) {
+            return null;
+        }
+        try {
+            return new URI(url).getHost();
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
+    private static String schemeOf(String url) {
+        if (url == null) {
+            return null;
+        }
+        try {
+            final String scheme = new URI(url).getScheme();
+            return scheme == null ? null : scheme.toLowerCase();
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/org/jahia/modules/downloadhelper/util/UrlSecurityUtilsTest.java
+++ b/src/test/java/org/jahia/modules/downloadhelper/util/UrlSecurityUtilsTest.java
@@ -1,0 +1,208 @@
+package org.jahia.modules.downloadhelper.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UrlSecurityUtilsTest {
+
+    @Nested
+    @DisplayName("sanitizeForLog")
+    class SanitizeForLog {
+
+        @Test
+        @DisplayName("returns null for null input")
+        void nullInput() {
+            assertThat(UrlSecurityUtils.sanitizeForLog(null)).isNull();
+        }
+
+        @Test
+        @DisplayName("strips CR and LF so forged log lines cannot be injected")
+        void stripsCrLf() {
+            final String malicious = "good\r\nERROR injected admin login from 10.0.0.1";
+            assertThat(UrlSecurityUtils.sanitizeForLog(malicious))
+                    .doesNotContain("\r")
+                    .doesNotContain("\n")
+                    .isEqualTo("good__ERROR injected admin login from 10.0.0.1");
+        }
+
+        @Test
+        @DisplayName("leaves clean input untouched")
+        void cleanInput() {
+            assertThat(UrlSecurityUtils.sanitizeForLog("https://example.com/file.zip"))
+                    .isEqualTo("https://example.com/file.zip");
+        }
+    }
+
+    @Nested
+    @DisplayName("isBlockedHost")
+    class IsBlockedHost {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @DisplayName("treats null/empty host as blocked (fail closed)")
+        void nullOrEmpty(String host) {
+            assertThat(UrlSecurityUtils.isBlockedHost(host)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"metadata", "metadata.google.internal", "metadata.goog", "METADATA.GOOGLE.INTERNAL"})
+        @DisplayName("blocks well-known cloud-metadata hostnames case-insensitively")
+        void blocksMetadataHosts(String host) {
+            assertThat(UrlSecurityUtils.isBlockedHost(host)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"example.com", "store.jahia.com", "metadata.example.com"})
+        @DisplayName("allows ordinary hosts")
+        void allowsOrdinaryHosts(String host) {
+            assertThat(UrlSecurityUtils.isBlockedHost(host)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isNonRoutableAddress")
+    class IsNonRoutableAddress {
+
+        @Test
+        @DisplayName("treats null address as non-routable (fail closed)")
+        void nullAddress() {
+            assertThat(UrlSecurityUtils.isNonRoutableAddress(null)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "127.0.0.1",          // loopback
+                "169.254.169.254",    // cloud metadata (link-local)
+                "10.0.0.5",           // site-local
+                "192.168.1.10",       // site-local
+                "172.16.0.1",         // site-local
+                "0.0.0.0",            // any-local
+                "224.0.0.1",          // multicast
+                "::1",                // IPv6 loopback
+                "fe80::1"             // IPv6 link-local
+        })
+        @DisplayName("rejects loopback / private / metadata / multicast addresses")
+        void rejectsNonRoutable(String ip) throws UnknownHostException {
+            // Literal IPs do not trigger DNS resolution.
+            assertThat(UrlSecurityUtils.isNonRoutableAddress(InetAddress.getByName(ip))).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"8.8.8.8", "1.1.1.1", "93.184.216.34"})
+        @DisplayName("allows public, routable addresses")
+        void allowsRoutable(String ip) throws UnknownHostException {
+            assertThat(UrlSecurityUtils.isNonRoutableAddress(InetAddress.getByName(ip))).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isRedirectStatus")
+    class IsRedirectStatus {
+
+        @ParameterizedTest
+        @ValueSource(ints = {301, 302, 303, 307, 308})
+        @DisplayName("recognizes the Location-bearing redirect codes")
+        void redirects(int code) {
+            assertThat(UrlSecurityUtils.isRedirectStatus(code)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {200, 204, 304, 400, 401, 403, 404, 500})
+        @DisplayName("does not treat non-redirect codes as redirects")
+        void nonRedirects(int code) {
+            assertThat(UrlSecurityUtils.isRedirectStatus(code)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isAllowedHttpScheme")
+    class IsAllowedHttpScheme {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"http://example.com/x", "https://example.com/x", "HTTPS://EXAMPLE.COM/x"})
+        @DisplayName("accepts http and https (case-insensitive)")
+        void acceptsHttp(String url) {
+            assertThat(UrlSecurityUtils.isAllowedHttpScheme(url)).isTrue();
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {
+                "ftp://example.com/x",
+                "file:///etc/passwd",
+                "gopher://example.com/",
+                "jar:file:///x!/y",
+                "/relative/path",
+                "not a url"
+        })
+        @DisplayName("rejects non-http schemes, relative and unparsable URLs")
+        void rejectsOthers(String url) {
+            assertThat(UrlSecurityUtils.isAllowedHttpScheme(url)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("resolveLocation")
+    class ResolveLocation {
+
+        @Test
+        @DisplayName("resolves an absolute Location verbatim")
+        void absolute() {
+            assertThat(UrlSecurityUtils.resolveLocation("https://a.com/x", "https://b.com/y"))
+                    .isEqualTo("https://b.com/y");
+        }
+
+        @Test
+        @DisplayName("resolves a relative Location against the current URL")
+        void relative() {
+            assertThat(UrlSecurityUtils.resolveLocation("https://a.com/dir/x", "/other/file.zip"))
+                    .isEqualTo("https://a.com/other/file.zip");
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        @DisplayName("returns null for blank locations")
+        void blank(String location) {
+            assertThat(UrlSecurityUtils.resolveLocation("https://a.com/x", location)).isNull();
+        }
+
+        @Test
+        @DisplayName("returns null when the current URL is null")
+        void nullCurrent() {
+            assertThat(UrlSecurityUtils.resolveLocation(null, "https://b.com")).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("sameHost")
+    class SameHost {
+
+        @Test
+        @DisplayName("true for identical hosts regardless of path or case")
+        void identical() {
+            assertThat(UrlSecurityUtils.sameHost("https://Example.com/a", "https://example.com/b/c")).isTrue();
+        }
+
+        @Test
+        @DisplayName("false when the redirect points at a different host (credentials must not follow)")
+        void different() {
+            assertThat(UrlSecurityUtils.sameHost("https://example.com/a", "https://evil.com/a")).isFalse();
+        }
+
+        @Test
+        @DisplayName("false when either URL has no parseable host")
+        void unparseable() {
+            assertThat(UrlSecurityUtils.sameHost("https://example.com", "not a url")).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the two residuals left by the prior hardening pass (commit `406ed1c`).

| # | Severity | Issue |
|---|----------|-------|
| **F1** | MEDIUM | SSRF guard bypass via HTTP redirects + Basic-auth credential leakage to redirect targets |
| **F2** | LOW | Log injection in `DownloadHelperMutationExtension.triggerDownload` async-failure path |

### F1 — Redirect-based SSRF (root cause)

`assertSafeHost` validated only the **initial** URL host. The shared Apache HttpClient followed 3xx redirects automatically, so a remote server (or one an `adminSystemInfos`-but-not-full-admin user is tricked into using) could `302 → http://169.254.169.254/` (or any internal / site-local host) and bypass the SSRF control entirely. Worse, the manually-added `Authorization: Basic` header was replayed on the redirect, leaking the admin's credentials to the redirect target.

**Fix:** disable `RequestConfig.setRedirectsEnabled` per-request and follow redirects manually in a bounded loop (max 5 hops). Every hop is re-validated with `assertSafeHost`; only `http`/`https` `Location` targets are honored; `Authorization` is added only when `UrlSecurityUtils.sameHost(currentUrl, initialUrl)`.

### F2 — Log injection
The mutation's async-failure log (`url`, `filename`, `currentUser`) is now routed through `UrlSecurityUtils.sanitizeForLog`, matching the service layer.

### Refactor
Pure SSRF/log-sanitization predicates are extracted into `org.jahia.modules.downloadhelper.util.UrlSecurityUtils` (no DNS / OSGi / I/O), so they can be unit-tested without a running Jahia. `assertSafeHost` and `BLOCKED_HOSTS` are consolidated through this helper — no duplicate predicates.

## Test plan

- [x] **Unit tests** — 58 JUnit 5 / AssertJ tests in `UrlSecurityUtilsTest` (`mvn test`):
  - CRLF stripping (null / clean / forged-log-line)
  - `isBlockedHost` — null/empty fails closed; `metadata*` matched case-insensitively; ordinary hosts allowed
  - `isNonRoutableAddress` — 127.0.0.1, 169.254.169.254, 10/8, 192.168/16, 172.16/12, 0.0.0.0, 224/4, ::1, fe80::/10 rejected; 8.8.8.8 / 1.1.1.1 / 93.184.216.34 allowed
  - `isRedirectStatus` — 301/302/303/307/308 true; 200/204/304/4xx/5xx false
  - `isAllowedHttpScheme` — http/https (case-insensitive) allowed; `ftp:`/`file:`/`gopher:`/`jar:`/relative/garbage rejected
  - `resolveLocation` — absolute pass-through, relative resolution, blank/null/unparseable returns null
  - `sameHost` — identical host (case + path tolerant) true; cross-host false; unparseable false
- [x] **Build green** — `mvn clean install -Dskip.installnodeyarn=true -Dskip.yarn=true` → `download-helper-2.0.5-SNAPSHOT.jar`
- [x] **Cypress E2E** — 13/13 specs passing against a live Jahia + freshly-built module jar, including the real-world redirect-following download from `store.jahia.com/cms/mavenproxy/...` — proves the bounded safe-redirect loop transparently handles legitimate Nexus redirects.

## Residual (documented, not fixed)

DNS-rebinding TOCTOU between `assertSafeHost` resolution and the client's connect-time resolution. Closing it requires IP pinning via a custom `HttpClientConnectionManager`, disproportionate for an `adminSystemInfos`-gated tool. See updated `AGENTS.md` § *Security invariants*.