### PR TITLE
fix: harden download filename handling (path traversal, DRY, blank-input validation)

### DIFF
--- a/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperMutationExtension.java
+++ b/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperMutationExtension.java
@@ -1,8 +1,8 @@
 package org.jahia.modules.downloadhelper.graphql;
 
 import graphql.annotations.annotationTypes.*;
-import org.apache.commons.io.FilenameUtils;
 import org.jahia.modules.downloadhelper.services.DownloadHelperService;
+import org.jahia.modules.downloadhelper.util.DownloadPaths;
 import org.jahia.modules.downloadhelper.util.UrlSecurityUtils;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
 import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
@@ -25,6 +25,10 @@ public class DownloadHelperMutationExtension {
     private DownloadHelperMutationExtension() {
     }
 
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
     @GraphQLField
     @GraphQLName("downloadHelperTrigger")
     @GraphQLDescription("Triggers an asynchronous file download on the server")
@@ -36,6 +40,11 @@ public class DownloadHelperMutationExtension {
             @GraphQLName("login") final String login,
             @GraphQLName("password") final String password,
             @GraphQLName("email") final String email) {
+
+        if (isBlank(protocol) || isBlank(url) || isBlank(filename)) {
+            LOGGER.warn("Rejected download trigger with blank protocol/url/filename");
+            return Boolean.FALSE;
+        }
 
         final DownloadHelperService service = BundleUtils.getOsgiService(DownloadHelperService.class, null);
         if (service == null) {
@@ -66,22 +75,11 @@ public class DownloadHelperMutationExtension {
     public static Boolean deleteFile(
             @GraphQLName("filename") @GraphQLNonNull final String filename) {
 
-        final String safeName = FilenameUtils.getName(filename);
-        if (safeName.isEmpty()) {
-            LOGGER.warn("Rejected empty or path-only filename: {}", filename);
-            return Boolean.FALSE;
-        }
-
-        final File file = new File(DownloadHelperService.DOWNLOAD_FOLDER_PATH, safeName);
+        final File file;
         try {
-            final String canonicalFile = file.getCanonicalPath();
-            final String canonicalFolder = new File(DownloadHelperService.DOWNLOAD_FOLDER_PATH).getCanonicalPath();
-            if (!canonicalFile.startsWith(canonicalFolder + File.separator)) {
-                LOGGER.warn("Path traversal attempt rejected for filename: {}", filename);
-                return Boolean.FALSE;
-            }
+            file = DownloadPaths.resolveContainedFile(DownloadHelperService.DOWNLOAD_FOLDER_PATH, filename);
         } catch (IOException e) {
-            LOGGER.error("Could not resolve canonical path for filename: {}", filename, e);
+            LOGGER.warn("Rejected unsafe filename for delete: {}", UrlSecurityUtils.sanitizeForLog(filename));
             return Boolean.FALSE;
         }
 

--- a/src/main/java/org/jahia/modules/downloadhelper/services/DownloadHelperService.java
+++ b/src/main/java/org/jahia/modules/downloadhelper/services/DownloadHelperService.java
@@ -1,6 +1,5 @@
 package org.jahia.modules.downloadhelper.services;
 
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.net.util.Base64;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -10,6 +9,7 @@ import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpStatus;
 import org.jahia.modules.downloadhelper.constants.Email;
+import org.jahia.modules.downloadhelper.util.DownloadPaths;
 import org.jahia.modules.downloadhelper.util.FileSizeUtils;
 import org.jahia.modules.downloadhelper.util.UrlSecurityUtils;
 import org.jahia.services.mail.MailService;
@@ -119,7 +119,17 @@ public class DownloadHelperService {
             return;
         }
 
-        final File targetFile = new File(DOWNLOAD_FOLDER_PATH, FilenameUtils.getName(filename));
+        final File targetFile;
+        try {
+            targetFile = DownloadPaths.resolveContainedFile(DOWNLOAD_FOLDER_PATH, filename);
+        } catch (IOException ex) {
+            if (LOGGER.isErrorEnabled()) {
+                LOGGER.error("Rejected unsafe filename for download asked by {}: {}",
+                        sanitizeForLog(user), sanitizeForLog(filename));
+            }
+            sendEmail(url, filename, ccEmail, user, Email.DOWNLOAD_FAILED_SUBJECT);
+            return;
+        }
         boolean result = false;
         try {
             if ("https".equals(protocol)) {

--- a/src/main/java/org/jahia/modules/downloadhelper/util/DownloadPaths.java
+++ b/src/main/java/org/jahia/modules/downloadhelper/util/DownloadPaths.java
@@ -1,0 +1,47 @@
+package org.jahia.modules.downloadhelper.util;
+
+import org.apache.commons.io.FilenameUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Resolves a user-supplied filename to a {@link File} that is provably contained within the
+ * download folder, rejecting path-traversal attempts.
+ *
+ * <p>{@link FilenameUtils#getName(String)} strips directory components but does <strong>not</strong>
+ * neutralize a bare {@code ".."} (it has no separator, so it is returned verbatim) nor a {@code null}.
+ * {@code new File(folder, "..")} would then resolve to the parent of the download folder. This helper
+ * closes that gap with a canonical-path containment check, mirroring the protection already applied to
+ * the delete mutation so that both the download and delete code paths share one tested implementation.</p>
+ */
+public final class DownloadPaths {
+
+    private DownloadPaths() {
+    }
+
+    /**
+     * Resolves {@code rawFilename} against {@code folderPath} and verifies the result stays inside the
+     * folder.
+     *
+     * @param folderPath  the absolute download folder path (trusted, hardcoded by the module)
+     * @param rawFilename the user-supplied filename (may be {@code null}, empty, path-only, or traversal)
+     * @return the contained target {@link File}
+     * @throws IOException if the filename is empty/path-only, escapes the folder, or cannot be resolved
+     */
+    public static File resolveContainedFile(String folderPath, String rawFilename) throws IOException {
+        final String safeName = FilenameUtils.getName(rawFilename);
+        if (safeName == null || safeName.isEmpty() || ".".equals(safeName) || "..".equals(safeName)) {
+            throw new IOException("Invalid or empty filename");
+        }
+
+        final File folder = new File(folderPath);
+        final File target = new File(folder, safeName);
+        final String canonicalFolder = folder.getCanonicalPath();
+        final String canonicalTarget = target.getCanonicalPath();
+        if (!canonicalTarget.startsWith(canonicalFolder + File.separator)) {
+            throw new IOException("Filename resolves outside the download folder");
+        }
+        return target;
+    }
+}

--- a/src/test/java/org/jahia/modules/downloadhelper/util/DownloadPathsTest.java
+++ b/src/test/java/org/jahia/modules/downloadhelper/util/DownloadPathsTest.java
@@ -1,0 +1,76 @@
+package org.jahia.modules.downloadhelper.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DownloadPathsTest {
+
+    @TempDir
+    Path folder;
+
+    @Test
+    @DisplayName("resolves a plain filename to a file directly inside the folder")
+    void plainFilename() throws IOException {
+        final File resolved = DownloadPaths.resolveContainedFile(folder.toString(), "report.zip");
+
+        assertThat(resolved.getParentFile().getCanonicalPath())
+                .isEqualTo(folder.toFile().getCanonicalPath());
+        assertThat(resolved.getName()).isEqualTo("report.zip");
+    }
+
+    @Test
+    @DisplayName("strips directory components and keeps only the base name")
+    void stripsDirectoryComponents() throws IOException {
+        final File resolved = DownloadPaths.resolveContainedFile(folder.toString(), "sub/dir/report.zip");
+
+        assertThat(resolved.getName()).isEqualTo("report.zip");
+        assertThat(resolved.getParentFile().getCanonicalPath())
+                .isEqualTo(folder.toFile().getCanonicalPath());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {".", "..", "sub/dir/", "../"})
+    @DisplayName("rejects null, empty, path-only and dot/dot-dot filenames")
+    void rejectsEmptyOrTraversalOnlyNames(String raw) {
+        assertThatThrownBy(() -> DownloadPaths.resolveContainedFile(folder.toString(), raw))
+                .isInstanceOf(IOException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "../../etc/passwd",
+            "../outside.txt",
+            "..\\..\\windows\\system32"
+    })
+    @DisplayName("collapses traversal sequences to a contained base name (never escapes the folder)")
+    void traversalCollapsesToContainedName(String raw) throws IOException {
+        // FilenameUtils.getName strips path separators (both / and \\), so these collapse to a base
+        // name that stays inside the folder. The security invariant is containment, not rejection.
+        final File resolved = DownloadPaths.resolveContainedFile(folder.toString(), raw);
+
+        assertThat(resolved.getCanonicalPath())
+                .startsWith(folder.toFile().getCanonicalPath() + File.separator);
+        assertThat(resolved.getName()).doesNotContain("..");
+    }
+
+    @Test
+    @DisplayName("a contained file never resolves outside the download folder")
+    void neverEscapesFolder() throws IOException {
+        final File resolved = DownloadPaths.resolveContainedFile(folder.toString(), "data.bin");
+
+        assertThat(resolved.getCanonicalPath())
+                .startsWith(folder.toFile().getCanonicalPath() + File.separator);
+    }
+}


### PR DESCRIPTION
## Summary

Behavior-preserving hardening of the download-helper module, focused on filename/path-traversal handling (the headline risk for a file-download module). The SSRF / redirect / log-injection defenses from SECURITY-746 were already solid; this PR closes the remaining filename gaps.

## Changes

- **S1/R1 — path traversal in `download()`**: `targetFile` was derived only via `FilenameUtils.getName(filename)`. `getName` returns `".."` verbatim (no separator to strip) and `null` for `null` input, so `new File(folder, "..")` could resolve to the *parent* of the download folder, and a null/empty name could NPE or target the folder directory. Added `DownloadPaths.resolveContainedFile` with a canonical-path containment check; rejects empty/`.`/`..` names and fails fast with a failure email.
- **S2/R2 — DRY**: `deleteFile()` duplicated the canonical-path containment logic inline. Now routes through the shared `DownloadPaths` helper so both download and delete share one tested implementation.
- **S3/R3 — boundary validation**: `triggerDownload()` spawned an async thread before validating its `@GraphQLNonNull` `protocol`/`url`/`filename` were non-blank. Now rejects blank input at the boundary before allocating a thread.

## Tests

- New `DownloadPathsTest` (JUnit 5 + AssertJ, matching repo convention): 12 cases — plain names, directory stripping, null/empty/path-only/dot rejection, traversal collapse to a contained base name, and folder containment.

## Build

`mvn clean install` — **BUILD SUCCESS**, 70 tests, 0 failures (12 new + 58 existing).

No Java version / pom compiler changes. No new dependencies (used JDK-only blank check).