### PR TITLE
feat: replace adminSystemInfos with module-specific adminDownloadHelper permission

### DIFF
--- a/src/javascript/DownloadHelper/register.jsx
+++ b/src/javascript/DownloadHelper/register.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 export default () => {
     registry.add('adminRoute', 'downloadHelper', {
         targets: ['administration-server-systemHealth:10'],
-        requiredPermission: 'adminSystemInfos',
+        requiredPermission: 'adminDownloadHelper',
         label: 'download-helper:label.menu_entry',
         isSelectable: true,
         render: () => React.createElement(DownloadHelperAdmin)

--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <admin jcr:primaryType="jnt:permission">
+        <adminDownloadHelper jcr:primaryType="jnt:permission"/>
+    </admin>
+</permissions>

--- a/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperMutationExtension.java
+++ b/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperMutationExtension.java
@@ -32,7 +32,7 @@ public class DownloadHelperMutationExtension {
     @GraphQLField
     @GraphQLName("downloadHelperTrigger")
     @GraphQLDescription("Triggers an asynchronous file download on the server")
-    @GraphQLRequiresPermission("adminSystemInfos")
+    @GraphQLRequiresPermission("adminDownloadHelper")
     public static Boolean triggerDownload(
             @GraphQLName("protocol") @GraphQLNonNull final String protocol,
             @GraphQLName("url") @GraphQLNonNull final String url,
@@ -71,7 +71,7 @@ public class DownloadHelperMutationExtension {
     @GraphQLField
     @GraphQLName("downloadHelperDeleteFile")
     @GraphQLDescription("Deletes a file from the download folder")
-    @GraphQLRequiresPermission("adminSystemInfos")
+    @GraphQLRequiresPermission("adminDownloadHelper")
     public static Boolean deleteFile(
             @GraphQLName("filename") @GraphQLNonNull final String filename) {
 

--- a/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperQueryExtension.java
+++ b/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperQueryExtension.java
@@ -37,7 +37,7 @@ public class DownloadHelperQueryExtension {
     @GraphQLField
     @GraphQLName("downloadHelperInfo")
     @GraphQLDescription("Returns server information for the download helper admin panel")
-    @GraphQLRequiresPermission("adminSystemInfos")
+    @GraphQLRequiresPermission("adminDownloadHelper")
     public static GqlServerInfo getDownloadHelperInfo() {
         final boolean isProcessingServer = SettingsBean.getInstance().isProcessingServer();
         final File downloadFolder = new File(DownloadHelperService.DOWNLOAD_FOLDER_PATH);
@@ -71,7 +71,7 @@ public class DownloadHelperQueryExtension {
     @GraphQLField
     @GraphQLName("downloadHelperFiles")
     @GraphQLDescription("Lists files present in the download folder, sorted by last modified date descending")
-    @GraphQLRequiresPermission("adminSystemInfos")
+    @GraphQLRequiresPermission("adminDownloadHelper")
     public static List<GqlDownloadedFile> getDownloadHelperFiles() {
         final File folder = new File(DownloadHelperService.DOWNLOAD_FOLDER_PATH);
         if (!folder.exists() || !folder.isDirectory()) {


### PR DESCRIPTION
## Summary

- Add `src/main/import/permissions.xml` defining `jnt:permission adminDownloadHelper` as a child of `admin`; the Jahia Maven plugin packages it into `import.zip` automatically.
- Replace all 4 `@GraphQLRequiresPermission("adminSystemInfos")` annotations in `DownloadHelperMutationExtension` (2) and `DownloadHelperQueryExtension` (2) with `@GraphQLRequiresPermission("adminDownloadHelper")`.
- No changes to Java logic, tests, or `pom.xml`.

## Test plan

- [ ] Verify `mvn clean install` passes (build is green — `import.zip` includes `permissions.xml`)
- [ ] Deploy module to a Jahia instance and confirm `adminDownloadHelper` permission appears under `admin` in the permission tree
- [ ] Confirm that a user holding `adminDownloadHelper` can call the GraphQL queries/mutations
- [ ] Confirm that a user holding only `adminSystemInfos` (but not `adminDownloadHelper`) is denied access
- [ ] Confirm that existing Cypress e2e tests pass unchanged