### PR TITLE
test: fine-grained permission regression tests + assignable admin role

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.jahia.community</groupId>
   <artifactId>download-helper</artifactId>
-  <version>2.0.5-SNAPSHOT</version>
+  <version>2.0.6-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>download-helper</name>
   <description>This is the custom module (download-helper) for running on a Digital Experience Manager server.</description>

--- a/src/javascript/DownloadHelper/register.jsx
+++ b/src/javascript/DownloadHelper/register.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 export default () => {
     registry.add('adminRoute', 'downloadHelper', {
         targets: ['administration-server-systemHealth:10'],
-        requiredPermission: 'adminSystemInfos',
+        requiredPermission: 'adminDownloadHelper',
         label: 'download-helper:label.menu_entry',
         isSelectable: true,
         render: () => React.createElement(DownloadHelperAdmin)

--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <admin jcr:primaryType="jnt:permission">
+        <adminDownloadHelper jcr:primaryType="jnt:permission"/>
+    </admin>
+</permissions>

--- a/src/main/import/roles.xml
+++ b/src/main/import/roles.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<roles jcr:primaryType="jnt:roles"
+       xmlns:jcr="http://www.jcp.org/jcr/1.0"
+       xmlns:j="http://www.jahia.org/jahia/1.0"
+       xmlns:jnt="http://www.jahia.org/jahia/nt/1.0">
+
+    <download-helper-administrator jcr:primaryType="jnt:role"
+                                   j:nodeTypes="rep:root"
+                                   j:roleGroup="server-role"
+                                   j:permissionNames="administrationAccess adminDownloadHelper"
+                                   j:privilegedAccess="true">
+        <j:translation_en jcr:primaryType="jnt:translation"
+                          jcr:language="en"
+                          jcr:title="Download Helper administrator"
+                          jcr:description="Grants access to the Download Helper administration without requiring full server administrator rights"/>
+    </download-helper-administrator>
+</roles>

--- a/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperMutationExtension.java
+++ b/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperMutationExtension.java
@@ -32,7 +32,7 @@ public class DownloadHelperMutationExtension {
     @GraphQLField
     @GraphQLName("downloadHelperTrigger")
     @GraphQLDescription("Triggers an asynchronous file download on the server")
-    @GraphQLRequiresPermission("adminSystemInfos")
+    @GraphQLRequiresPermission("adminDownloadHelper")
     public static Boolean triggerDownload(
             @GraphQLName("protocol") @GraphQLNonNull final String protocol,
             @GraphQLName("url") @GraphQLNonNull final String url,
@@ -71,7 +71,7 @@ public class DownloadHelperMutationExtension {
     @GraphQLField
     @GraphQLName("downloadHelperDeleteFile")
     @GraphQLDescription("Deletes a file from the download folder")
-    @GraphQLRequiresPermission("adminSystemInfos")
+    @GraphQLRequiresPermission("adminDownloadHelper")
     public static Boolean deleteFile(
             @GraphQLName("filename") @GraphQLNonNull final String filename) {
 

--- a/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperQueryExtension.java
+++ b/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperQueryExtension.java
@@ -37,7 +37,7 @@ public class DownloadHelperQueryExtension {
     @GraphQLField
     @GraphQLName("downloadHelperInfo")
     @GraphQLDescription("Returns server information for the download helper admin panel")
-    @GraphQLRequiresPermission("adminSystemInfos")
+    @GraphQLRequiresPermission("adminDownloadHelper")
     public static GqlServerInfo getDownloadHelperInfo() {
         final boolean isProcessingServer = SettingsBean.getInstance().isProcessingServer();
         final File downloadFolder = new File(DownloadHelperService.DOWNLOAD_FOLDER_PATH);
@@ -71,7 +71,7 @@ public class DownloadHelperQueryExtension {
     @GraphQLField
     @GraphQLName("downloadHelperFiles")
     @GraphQLDescription("Lists files present in the download folder, sorted by last modified date descending")
-    @GraphQLRequiresPermission("adminSystemInfos")
+    @GraphQLRequiresPermission("adminDownloadHelper")
     public static List<GqlDownloadedFile> getDownloadHelperFiles() {
         final File folder = new File(DownloadHelperService.DOWNLOAD_FOLDER_PATH);
         if (!folder.exists() || !folder.isDirectory()) {

--- a/tests/cypress/e2e/02-downloadHelper-Permissions.cy.ts
+++ b/tests/cypress/e2e/02-downloadHelper-Permissions.cy.ts
@@ -1,0 +1,85 @@
+import {DocumentNode} from 'graphql';
+import {createUser, deleteUser, grantRoles} from '@jahia/cypress';
+
+/**
+ * Regression tests for the fine-grained `adminDownloadHelper` permission.
+ *
+ * These guard against the gate being silently removed or mismatched across the stack:
+ *  - Backend: `@GraphQLRequiresPermission("adminDownloadHelper")` is enforced as
+ *    `session.getNode("/").hasPermission("adminDownloadHelper")` (root-node ACL check).
+ *  - Frontend: `requiredPermission: 'adminDownloadHelper'` in register.jsx gates the admin route.
+ *  - RBAC content: the module ships the assignable `download-helper-administrator` role
+ *    (src/main/import/roles.xml) granting ONLY `administrationAccess adminDownloadHelper`.
+ *
+ * The "allowed" user is granted that role and nothing else — never `admin` — so the tests prove
+ * fine-grained granularity, not merely that a full administrator can pass.
+ */
+describe('Download Helper — permission enforcement', () => {
+    const ROLE_NAME = 'download-helper-administrator';
+    const DENIED_USER = 'dhDeniedUser';
+    const ALLOWED_USER = 'dhAllowedUser';
+    const PASSWORD = 'DhPerm9PwdTest';
+    const ADMIN_PATH = '/jahia/administration/downloadHelper';
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const getDownloadHelperInfo: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/query/getDownloadHelperInfo.graphql');
+
+    const errorsOf = (result: {graphQLErrors?: Array<{message: string}>; errors?: Array<{message: string}>}) =>
+        result.graphQLErrors ?? result.errors ?? [];
+
+    const queryInfoAs = (username: string) => {
+        cy.apolloClient({username, password: PASSWORD});
+        return cy.apollo({query: getDownloadHelperInfo});
+    };
+
+    before(() => {
+        cy.login();
+        createUser(DENIED_USER, PASSWORD);
+        createUser(ALLOWED_USER, PASSWORD);
+        // The annotation resolves the permission on the JCR root node, so grant the
+        // module-shipped single-permission role on `/`.
+        grantRoles('/', [ROLE_NAME], ALLOWED_USER, 'USER');
+    });
+
+    after(() => {
+        cy.apolloClient(); // reset the current Apollo client back to root
+        cy.login();
+        deleteUser(DENIED_USER);
+        deleteUser(ALLOWED_USER);
+    });
+
+    describe('GraphQL API authorization', () => {
+        it('denies the gated query for a user without the permission', () => {
+            queryInfoAs(DENIED_USER).then((result: never) => {
+                const errs = errorsOf(result);
+                expect(errs, 'denial errors').to.have.length.greaterThan(0);
+                expect(errs.map((e: {message: string}) => e.message).join(' ')).to.contain('Permission denied');
+            });
+        });
+
+        it('allows the gated query for a user granted only the module permission', () => {
+            queryInfoAs(ALLOWED_USER).then((result: never) => {
+                expect(errorsOf(result), 'should have no errors').to.have.length(0);
+                const info = (result as {data: {downloadHelperInfo: {downloadFolderPath: string}}}).data.downloadHelperInfo;
+                expect(info).to.have.property('isProcessingServer');
+                expect(info).to.have.property('availableSpace');
+                expect(info).to.have.property('downloadFolderPath');
+                expect(info).to.have.property('isMailActivated');
+            });
+        });
+    });
+
+    describe('Admin UI authorization', () => {
+        it('hides the admin panel from a user without the permission', () => {
+            cy.login(DENIED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH, {failOnStatusCode: false});
+            cy.get('#dh-url').should('not.exist');
+        });
+
+        it('shows the admin panel to a user granted only the module permission', () => {
+            cy.login(ALLOWED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH);
+            cy.get('#dh-url').should('be.visible');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds regression coverage for the fine-grained `adminDownloadHelper` permission (introduced in #feat/fine-grained-permissions, replacing the former `adminSystemInfos`) plus an assignable server role, so the permission gate cannot be silently removed or mismatched across the stack.

- **`src/main/import/roles.xml`** — ships an assignable `download-helper-administrator` server role granting **only** `administrationAccess adminDownloadHelper` (never full `admin`). `administrationAccess` is required so the admin UI entry renders for the granted user.
- **`tests/cypress/e2e/02-downloadHelper-Permissions.cy.ts`** — 4 permission tests:
  - **GraphQL deny**: a user without the permission is rejected on the gated `downloadHelperInfo` query (`Permission denied`).
  - **GraphQL allow**: a user granted *only* the module role gets full success — data returned, zero errors.
  - **UI hidden**: the admin panel (`#dh-url`) does not exist for the denied user at `/jahia/administration/downloadHelper`.
  - **UI shown**: the admin panel is visible for the granted user.
- **`pom.xml`** — version bump `2.0.5-SNAPSHOT` → `2.0.6-SNAPSHOT` so the new import content (`roles.xml`) re-imports on deploy.

The "allowed" user is granted the single-permission role and nothing else, so the tests prove fine-grained granularity, not merely that a full administrator passes.

### Note on base branch
Based on `feat/fine-grained-permissions` because that branch introduces the `adminDownloadHelper` permission the tests rely on; it does not yet exist on `master`. Retarget to `master` once the permission rename is merged.

### Java relaxation
None needed. The resolvers gate solely via `@GraphQLRequiresPermission("adminDownloadHelper")` (root-node ACL) — there is no inner hardcoded `admin` / `adminSystemInfos` check on the data path — so the allow test asserts full success without any `.java` change.

## Test plan

- [x] `mvn clean install` — module builds; fresh jar embeds `roles.xml`.
- [x] `./ci.build.sh && ./ci.startup.sh` → **17/17 specs pass** (13 existing in `01-downloadHelper.cy.ts` + 4 new permission tests). No regressions.
- [x] Jahia license health clean (0 license errors in container logs).