### PR TITLE
refactor: nest GraphQL operations under a downloadHelper namespace container

### DIFF
--- a/src/javascript/DownloadHelper/DownloadHelper.gql.js
+++ b/src/javascript/DownloadHelper/DownloadHelper.gql.js
@@ -2,28 +2,34 @@ import {gql} from '@apollo/client';
 
 export const GET_DOWNLOAD_HELPER_INFO = gql`
     query DownloadHelperInfo {
-        downloadHelperInfo {
-            isProcessingServer
-            availableSpace
-            downloadFolderPath
-            isMailActivated
+        downloadHelper {
+            info {
+                isProcessingServer
+                availableSpace
+                downloadFolderPath
+                isMailActivated
+            }
         }
     }
 `;
 
 export const GET_DOWNLOAD_HELPER_FILES = gql`
     query DownloadHelperFiles {
-        downloadHelperFiles {
-            name
-            size
-            lastModified
+        downloadHelper {
+            files {
+                name
+                size
+                lastModified
+            }
         }
     }
 `;
 
 export const DELETE_DOWNLOADED_FILE = gql`
     mutation DeleteDownloadedFile($filename: String!) {
-        downloadHelperDeleteFile(filename: $filename)
+        downloadHelper {
+            deleteFile(filename: $filename)
+        }
     }
 `;
 
@@ -36,13 +42,15 @@ export const TRIGGER_DOWNLOAD = gql`
         $password: String
         $email: String
     ) {
-        downloadHelperTrigger(
-            protocol: $protocol
-            url: $url
-            filename: $filename
-            login: $login
-            password: $password
-            email: $email
-        )
+        downloadHelper {
+            trigger(
+                protocol: $protocol
+                url: $url
+                filename: $filename
+                login: $login
+                password: $password
+                email: $email
+            )
+        }
     }
 `;

--- a/src/javascript/DownloadHelper/DownloadHelper.jsx
+++ b/src/javascript/DownloadHelper/DownloadHelper.jsx
@@ -489,7 +489,7 @@ export const DownloadHelperAdmin = () => {
                     email: email || null
                 }
             });
-            if (result.data?.downloadHelperTrigger === true) {
+            if (result.data?.downloadHelper?.trigger === true) {
                 setTriggerStatus('success');
                 resetForm();
             } else {
@@ -572,13 +572,13 @@ export const DownloadHelperAdmin = () => {
         );
     }
 
-    const info = data?.downloadHelperInfo;
+    const info = data?.downloadHelper?.info;
 
     if (!info || !info.isProcessingServer) {
         return <NotProcessingServer t={t}/>;
     }
 
-    const files = filesData?.downloadHelperFiles;
+    const files = filesData?.downloadHelper?.files;
     const hasFiles = !filesLoading && files && files.length > 0;
     const showEmpty = !filesLoading && !filesError && (!files || files.length === 0);
 

--- a/src/javascript/DownloadHelper/DownloadHelper.test.jsx
+++ b/src/javascript/DownloadHelper/DownloadHelper.test.jsx
@@ -59,7 +59,7 @@ jest.mock('@jahia/moonstone', () => ({
 
 const {useQuery, useMutation} = require('@apollo/client');
 
-function setupMocks({infoData, filesData, triggerResult = {data: {downloadHelperTrigger: true}}}) {
+function setupMocks({infoData, filesData, triggerResult = {data: {downloadHelper: {trigger: true}}}}) {
     // Identify the query by its parsed operation name so re-renders don't skew a counter.
     useQuery.mockImplementation(query => {
         const opName = query?.definitions?.[0]?.name?.value || '';
@@ -88,15 +88,17 @@ function setupMocks({infoData, filesData, triggerResult = {data: {downloadHelper
 }
 
 const defaultInfo = {
-    downloadHelperInfo: {
-        isProcessingServer: true,
-        isMailActivated: true,
-        availableSpace: '10 GiB',
-        downloadFolderPath: '/tmp/jahia-download-helper'
+    downloadHelper: {
+        info: {
+            isProcessingServer: true,
+            isMailActivated: true,
+            availableSpace: '10 GiB',
+            downloadFolderPath: '/tmp/jahia-download-helper'
+        }
     }
 };
 
-const defaultFiles = {downloadHelperFiles: []};
+const defaultFiles = {downloadHelper: {files: []}};
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -111,11 +113,13 @@ describe('DownloadHelperAdmin', () => {
         // Arrange
         setupMocks({
             infoData: {
-                downloadHelperInfo: {
-                    isProcessingServer: true,
-                    isMailActivated: false,
-                    availableSpace: 'x',
-                    downloadFolderPath: '/tmp'
+                downloadHelper: {
+                    info: {
+                        isProcessingServer: true,
+                        isMailActivated: false,
+                        availableSpace: 'x',
+                        downloadFolderPath: '/tmp'
+                    }
                 }
             },
             filesData: defaultFiles
@@ -137,11 +141,13 @@ describe('DownloadHelperAdmin', () => {
         // Arrange
         setupMocks({
             infoData: {
-                downloadHelperInfo: {
-                    isProcessingServer: false,
-                    isMailActivated: true,
-                    availableSpace: '0',
-                    downloadFolderPath: '/tmp'
+                downloadHelper: {
+                    info: {
+                        isProcessingServer: false,
+                        isMailActivated: true,
+                        availableSpace: '0',
+                        downloadFolderPath: '/tmp'
+                    }
                 }
             },
             filesData: defaultFiles
@@ -162,7 +168,7 @@ describe('DownloadHelperAdmin', () => {
         setupMocks({
             infoData: defaultInfo,
             filesData: defaultFiles,
-            triggerResult: {data: {downloadHelperTrigger: false}}
+            triggerResult: {data: {downloadHelper: {trigger: false}}}
         });
 
         render(<DownloadHelperAdmin/>);

--- a/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperMutation.java
+++ b/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperMutation.java
@@ -1,0 +1,87 @@
+package org.jahia.modules.downloadhelper.graphql;
+
+import graphql.annotations.annotationTypes.*;
+import org.jahia.modules.downloadhelper.constants.DownloadHelperConstants;
+import org.jahia.modules.downloadhelper.services.DownloadHelperService;
+import org.jahia.modules.downloadhelper.util.DownloadPaths;
+import org.jahia.modules.downloadhelper.util.UrlSecurityUtils;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
+import org.jahia.osgi.BundleUtils;
+import org.jahia.services.content.JCRSessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+@GraphQLName("DownloadHelperMutation")
+@GraphQLDescription("Download Helper mutations")
+public class DownloadHelperMutation {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DownloadHelperMutation.class);
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    @GraphQLField
+    @GraphQLName("trigger")
+    @GraphQLDescription("Triggers an asynchronous file download on the server")
+    @GraphQLRequiresPermission(DownloadHelperConstants.PERMISSION)
+    public Boolean triggerDownload(
+            @GraphQLName("protocol") @GraphQLNonNull final String protocol,
+            @GraphQLName("url") @GraphQLNonNull final String url,
+            @GraphQLName("filename") @GraphQLNonNull final String filename,
+            @GraphQLName("login") final String login,
+            @GraphQLName("password") final String password,
+            @GraphQLName("email") final String email) {
+
+        if (isBlank(protocol) || isBlank(url) || isBlank(filename)) {
+            LOGGER.warn("Rejected download trigger with blank protocol/url/filename");
+            return Boolean.FALSE;
+        }
+
+        final DownloadHelperService service = BundleUtils.getOsgiService(DownloadHelperService.class, null);
+        if (service == null) {
+            LOGGER.error("DownloadHelperService is not available");
+            return Boolean.FALSE;
+        }
+
+        final String currentUser = JCRSessionFactory.getInstance().getCurrentUser().getUserKey();
+
+        // Execution is delegated to the service-owned, bundle-lifecycle-tied executor rather than a
+        // raw thread, so downloads are shut down cleanly when the bundle is deactivated.
+        service.submitDownload(protocol, url, login, password, filename, email, currentUser);
+
+        return Boolean.TRUE;
+    }
+
+    @GraphQLField
+    @GraphQLName("deleteFile")
+    @GraphQLDescription("Deletes a file from the download folder")
+    @GraphQLRequiresPermission("adminDownloadHelper")
+    public Boolean deleteFile(
+            @GraphQLName("filename") @GraphQLNonNull final String filename) {
+
+        final File file;
+        try {
+            file = DownloadPaths.resolveContainedFile(DownloadHelperService.DOWNLOAD_FOLDER_PATH, filename);
+        } catch (IOException e) {
+            LOGGER.warn("Rejected unsafe filename for delete: {}", UrlSecurityUtils.sanitizeForLog(filename));
+            return Boolean.FALSE;
+        }
+
+        if (!file.exists()) {
+            return Boolean.FALSE;
+        }
+
+        try {
+            Files.delete(file.toPath());
+            return Boolean.TRUE;
+        } catch (IOException e) {
+            LOGGER.warn("Could not delete file: {}", file.getAbsolutePath(), e);
+            return Boolean.FALSE;
+        }
+    }
+}

--- a/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperMutationExtension.java
+++ b/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperMutationExtension.java
@@ -1,92 +1,22 @@
 package org.jahia.modules.downloadhelper.graphql;
 
-import graphql.annotations.annotationTypes.*;
-import org.jahia.modules.downloadhelper.constants.DownloadHelperConstants;
-import org.jahia.modules.downloadhelper.services.DownloadHelperService;
-import org.jahia.modules.downloadhelper.util.DownloadPaths;
-import org.jahia.modules.downloadhelper.util.UrlSecurityUtils;
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
-import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
-import org.jahia.osgi.BundleUtils;
-import org.jahia.services.content.JCRSessionFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 
 @GraphQLTypeExtension(DXGraphQLProvider.Mutation.class)
-@GraphQLName("DownloadHelperMutations")
 @GraphQLDescription("Download Helper mutations")
 public class DownloadHelperMutationExtension {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(DownloadHelperMutationExtension.class);
 
     private DownloadHelperMutationExtension() {
     }
 
-    private static boolean isBlank(String value) {
-        return value == null || value.trim().isEmpty();
-    }
-
     @GraphQLField
-    @GraphQLName("downloadHelperTrigger")
-    @GraphQLDescription("Triggers an asynchronous file download on the server")
-    @GraphQLRequiresPermission(DownloadHelperConstants.PERMISSION)
-    public static Boolean triggerDownload(
-            @GraphQLName("protocol") @GraphQLNonNull final String protocol,
-            @GraphQLName("url") @GraphQLNonNull final String url,
-            @GraphQLName("filename") @GraphQLNonNull final String filename,
-            @GraphQLName("login") final String login,
-            @GraphQLName("password") final String password,
-            @GraphQLName("email") final String email) {
-
-        if (isBlank(protocol) || isBlank(url) || isBlank(filename)) {
-            LOGGER.warn("Rejected download trigger with blank protocol/url/filename");
-            return Boolean.FALSE;
-        }
-
-        final DownloadHelperService service = BundleUtils.getOsgiService(DownloadHelperService.class, null);
-        if (service == null) {
-            LOGGER.error("DownloadHelperService is not available");
-            return Boolean.FALSE;
-        }
-
-        final String currentUser = JCRSessionFactory.getInstance().getCurrentUser().getUserKey();
-
-        // Execution is delegated to the service-owned, bundle-lifecycle-tied executor rather than a
-        // raw thread, so downloads are shut down cleanly when the bundle is deactivated.
-        service.submitDownload(protocol, url, login, password, filename, email, currentUser);
-
-        return Boolean.TRUE;
-    }
-
-    @GraphQLField
-    @GraphQLName("downloadHelperDeleteFile")
-    @GraphQLDescription("Deletes a file from the download folder")
-    @GraphQLRequiresPermission("adminDownloadHelper")
-    public static Boolean deleteFile(
-            @GraphQLName("filename") @GraphQLNonNull final String filename) {
-
-        final File file;
-        try {
-            file = DownloadPaths.resolveContainedFile(DownloadHelperService.DOWNLOAD_FOLDER_PATH, filename);
-        } catch (IOException e) {
-            LOGGER.warn("Rejected unsafe filename for delete: {}", UrlSecurityUtils.sanitizeForLog(filename));
-            return Boolean.FALSE;
-        }
-
-        if (!file.exists()) {
-            return Boolean.FALSE;
-        }
-
-        try {
-            Files.delete(file.toPath());
-            return Boolean.TRUE;
-        } catch (IOException e) {
-            LOGGER.warn("Could not delete file: {}", file.getAbsolutePath(), e);
-            return Boolean.FALSE;
-        }
+    @GraphQLName("downloadHelper")
+    @GraphQLDescription("Download Helper mutation namespace")
+    public static DownloadHelperMutation downloadHelper() {
+        return new DownloadHelperMutation();
     }
 }

--- a/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperQuery.java
+++ b/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperQuery.java
@@ -1,0 +1,80 @@
+package org.jahia.modules.downloadhelper.graphql;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import org.jahia.modules.downloadhelper.constants.DownloadHelperConstants;
+import org.jahia.modules.downloadhelper.services.DownloadHelperService;
+import org.jahia.modules.downloadhelper.util.FileSizeUtils;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
+import org.jahia.osgi.BundleUtils;
+import org.jahia.services.mail.MailService;
+import org.jahia.settings.SettingsBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@GraphQLName("DownloadHelperQuery")
+@GraphQLDescription("Download Helper queries")
+public class DownloadHelperQuery {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DownloadHelperQuery.class);
+
+    @GraphQLField
+    @GraphQLName("info")
+    @GraphQLDescription("Returns server information for the download helper admin panel")
+    @GraphQLRequiresPermission(DownloadHelperConstants.PERMISSION)
+    public GqlServerInfo getDownloadHelperInfo() {
+        final boolean isProcessingServer = SettingsBean.getInstance().isProcessingServer();
+        // A read must not mutate the filesystem: reflect the current state rather than creating the folder.
+        final File downloadFolder = new File(DownloadHelperService.DOWNLOAD_FOLDER_PATH);
+        String availableSpace = "0";
+        if (downloadFolder.exists()) {
+            try {
+                final long spaceBytes = Files.getFileStore(
+                        Paths.get(DownloadHelperService.DOWNLOAD_FOLDER_PATH)).getUsableSpace();
+                if (spaceBytes > 0) {
+                    availableSpace = FileSizeUtils.format(spaceBytes);
+                }
+            } catch (IOException e) {
+                LOGGER.warn("Could not determine available disk space", e);
+            }
+        }
+
+        final MailService mailService = BundleUtils.getOsgiService(MailService.class, null);
+        final boolean isMailActivated = mailService != null && mailService.getSettings() != null
+                && mailService.getSettings().isServiceActivated();
+
+        return new GqlServerInfo(isProcessingServer, availableSpace, DownloadHelperService.DOWNLOAD_FOLDER_PATH, isMailActivated);
+    }
+
+    @GraphQLField
+    @GraphQLName("files")
+    @GraphQLDescription("Lists files present in the download folder, sorted by last modified date descending")
+    @GraphQLRequiresPermission(DownloadHelperConstants.PERMISSION)
+    public List<GqlDownloadedFile> getDownloadHelperFiles() {
+        final File folder = new File(DownloadHelperService.DOWNLOAD_FOLDER_PATH);
+        if (!folder.exists() || !folder.isDirectory()) {
+            return Collections.emptyList();
+        }
+
+        final File[] files = folder.listFiles(File::isFile);
+        if (files == null) {
+            return Collections.emptyList();
+        }
+
+        return Arrays.stream(files)
+                .sorted(Comparator.comparingLong(File::lastModified).reversed())
+                .map(f -> new GqlDownloadedFile(f.getName(), f.length(), f.lastModified()))
+                .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperQueryExtension.java
+++ b/src/main/java/org/jahia/modules/downloadhelper/graphql/DownloadHelperQueryExtension.java
@@ -4,83 +4,19 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
-import org.jahia.modules.downloadhelper.constants.DownloadHelperConstants;
-import org.jahia.modules.downloadhelper.services.DownloadHelperService;
-import org.jahia.modules.downloadhelper.util.FileSizeUtils;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
-import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
-import org.jahia.osgi.BundleUtils;
-import org.jahia.services.mail.MailService;
-import org.jahia.settings.SettingsBean;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @GraphQLTypeExtension(DXGraphQLProvider.Query.class)
-@GraphQLName("DownloadHelperQueries")
 @GraphQLDescription("Download Helper queries")
 public class DownloadHelperQueryExtension {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(DownloadHelperQueryExtension.class);
 
     private DownloadHelperQueryExtension() {
     }
 
     @GraphQLField
-    @GraphQLName("downloadHelperInfo")
-    @GraphQLDescription("Returns server information for the download helper admin panel")
-    @GraphQLRequiresPermission(DownloadHelperConstants.PERMISSION)
-    public static GqlServerInfo getDownloadHelperInfo() {
-        final boolean isProcessingServer = SettingsBean.getInstance().isProcessingServer();
-        // A read must not mutate the filesystem: reflect the current state rather than creating the folder.
-        final File downloadFolder = new File(DownloadHelperService.DOWNLOAD_FOLDER_PATH);
-        String availableSpace = "0";
-        if (downloadFolder.exists()) {
-            try {
-                final long spaceBytes = Files.getFileStore(
-                        Paths.get(DownloadHelperService.DOWNLOAD_FOLDER_PATH)).getUsableSpace();
-                if (spaceBytes > 0) {
-                    availableSpace = FileSizeUtils.format(spaceBytes);
-                }
-            } catch (IOException e) {
-                LOGGER.warn("Could not determine available disk space", e);
-            }
-        }
-
-        final MailService mailService = BundleUtils.getOsgiService(MailService.class, null);
-        final boolean isMailActivated = mailService != null && mailService.getSettings() != null
-                && mailService.getSettings().isServiceActivated();
-
-        return new GqlServerInfo(isProcessingServer, availableSpace, DownloadHelperService.DOWNLOAD_FOLDER_PATH, isMailActivated);
-    }
-
-    @GraphQLField
-    @GraphQLName("downloadHelperFiles")
-    @GraphQLDescription("Lists files present in the download folder, sorted by last modified date descending")
-    @GraphQLRequiresPermission(DownloadHelperConstants.PERMISSION)
-    public static List<GqlDownloadedFile> getDownloadHelperFiles() {
-        final File folder = new File(DownloadHelperService.DOWNLOAD_FOLDER_PATH);
-        if (!folder.exists() || !folder.isDirectory()) {
-            return Collections.emptyList();
-        }
-
-        final File[] files = folder.listFiles(File::isFile);
-        if (files == null) {
-            return Collections.emptyList();
-        }
-
-        return Arrays.stream(files)
-                .sorted(Comparator.comparingLong(File::lastModified).reversed())
-                .map(f -> new GqlDownloadedFile(f.getName(), f.length(), f.lastModified()))
-                .collect(Collectors.toUnmodifiableList());
+    @GraphQLName("downloadHelper")
+    @GraphQLDescription("Download Helper query namespace")
+    public static DownloadHelperQuery downloadHelper() {
+        return new DownloadHelperQuery();
     }
 }

--- a/tests/cypress/e2e/01-downloadHelper.cy.ts
+++ b/tests/cypress/e2e/01-downloadHelper.cy.ts
@@ -18,7 +18,7 @@ describe('Download Helper', () => {
 
     it('returns server info via GraphQL', () => {
         cy.apollo({query: getDownloadHelperInfo})
-            .its('data.downloadHelperInfo')
+            .its('data.downloadHelper.info')
             .should(info => {
                 expect(info).to.have.property('isProcessingServer');
                 expect(info).to.have.property('availableSpace');
@@ -105,7 +105,7 @@ describe('Download Helper', () => {
 
     it('returns an empty file list via GraphQL when no files are present', () => {
         cy.apollo({query: getDownloadHelperFiles})
-            .its('data.downloadHelperFiles')
+            .its('data.downloadHelper.files')
             .should('be.an', 'array');
     });
 
@@ -121,7 +121,7 @@ describe('Download Helper', () => {
                 email: null
             }
         })
-            .its('data.downloadHelperTrigger')
+            .its('data.downloadHelper.trigger')
             .should('eq', true);
         cy.apollo({
             mutation: deleteDownloadedFile,
@@ -145,7 +145,7 @@ describe('Download Helper', () => {
             mutation: deleteDownloadedFile,
             variables: {filename: 'does-not-exist.txt'}
         })
-            .its('data.downloadHelperDeleteFile')
+            .its('data.downloadHelper.deleteFile')
             .should('eq', false);
     });
 
@@ -154,7 +154,7 @@ describe('Download Helper', () => {
             mutation: deleteDownloadedFile,
             variables: {filename: '../../../etc/passwd'}
         })
-            .its('data.downloadHelperDeleteFile')
+            .its('data.downloadHelper.deleteFile')
             .should('eq', false);
     });
 

--- a/tests/cypress/e2e/02-downloadHelper-Permissions.cy.ts
+++ b/tests/cypress/e2e/02-downloadHelper-Permissions.cy.ts
@@ -71,7 +71,7 @@ describe('Download Helper — permission enforcement', () => {
         it('allows the gated query for a user granted only the module permission', () => {
             queryInfoAs(ALLOWED_USER).then((result: never) => {
                 expect(errorsOf(result), 'should have no errors').to.have.length(0);
-                const info = (result as {data: {downloadHelperInfo: {downloadFolderPath: string}}}).data.downloadHelperInfo;
+                const info = (result as {data: {downloadHelper: {info: {downloadFolderPath: string}}}}).data.downloadHelper.info;
                 expect(info).to.have.property('isProcessingServer');
                 expect(info).to.have.property('availableSpace');
                 expect(info).to.have.property('downloadFolderPath');

--- a/tests/cypress/fixtures/graphql/mutation/deleteDownloadedFile.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/deleteDownloadedFile.graphql
@@ -1,3 +1,5 @@
 mutation DeleteDownloadedFile($filename: String!) {
-    downloadHelperDeleteFile(filename: $filename)
+    downloadHelper {
+        deleteFile(filename: $filename)
+    }
 }

--- a/tests/cypress/fixtures/graphql/mutation/triggerDownload.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/triggerDownload.graphql
@@ -6,12 +6,14 @@ mutation TriggerDownload(
     $password: String
     $email: String
 ) {
-    downloadHelperTrigger(
-        protocol: $protocol
-        url: $url
-        filename: $filename
-        login: $login
-        password: $password
-        email: $email
-    )
+    downloadHelper {
+        trigger(
+            protocol: $protocol
+            url: $url
+            filename: $filename
+            login: $login
+            password: $password
+            email: $email
+        )
+    }
 }

--- a/tests/cypress/fixtures/graphql/query/getDownloadHelperFiles.graphql
+++ b/tests/cypress/fixtures/graphql/query/getDownloadHelperFiles.graphql
@@ -1,7 +1,9 @@
 query GetDownloadHelperFiles {
-    downloadHelperFiles {
-        name
-        size
-        lastModified
+    downloadHelper {
+        files {
+            name
+            size
+            lastModified
+        }
     }
 }

--- a/tests/cypress/fixtures/graphql/query/getDownloadHelperInfo.graphql
+++ b/tests/cypress/fixtures/graphql/query/getDownloadHelperInfo.graphql
@@ -1,8 +1,10 @@
 query GetDownloadHelperInfo {
-    downloadHelperInfo {
-        isProcessingServer
-        availableSpace
-        downloadFolderPath
-        isMailActivated
+    downloadHelper {
+        info {
+            isProcessingServer
+            availableSpace
+            downloadFolderPath
+            isMailActivated
+        }
     }
 }


### PR DESCRIPTION
## What & why
Brings the module in line with the Jahia GraphQL convention: group operations under **one hierarchical namespace container** instead of flat, prefix-named root fields.

### Schema change (breaking)
```graphql
# before: query { downloadHelperInfo { ... } }   mutation { downloadHelperTrigger(...) }
# after:  query { downloadHelper { info { ... } } }  mutation { downloadHelper { trigger(...) } }
```

### How
- New holder types `DownloadHelperQuery` / `DownloadHelperMutation` hold the operations as instance `@GraphQLField` methods (`info`, `files`, `trigger`, `deleteFile`); the `*Extension` classes keep a single `downloadHelper` accessor field.
- `@GraphQLRequiresPermission` stays on each leaf — authorization unchanged.
- Frontend (`DownloadHelper.gql.js`/`.jsx`), the jest unit test (`DownloadHelper.test.jsx` mock shapes), and Cypress fixtures/specs updated in lockstep.

## Verification
- `mvn clean install` (JDK17): **BUILD SUCCESS**, 112 JUnit tests pass, webpack OK
- jest: **13/13 pass** (incl. updated DownloadHelper.test.jsx)
- Cypress E2E: **20/20 pass** (functional + permission)
- SonarQube quality gate: **OK** (0 new issues, 0 duplication)