### PR TITLE
refactor: rename root package org.jahia.modules.* → org.jahia.community.*

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Jahia OSGi module that lets admins trigger server-side file downloads (HTTPS or 
 
 - **artifactId**: `download-helper` | **version**: `2.0.6-SNAPSHOT` (pom.xml)
 - **npm version**: `2.0.3-SNAPSHOT` (package.json)
-- **Java package**: `org.jahia.modules.downloadhelper`
+- **Java package**: `org.jahia.community.downloadhelper`
 - **jahia-depends**: `serverSettings,graphql-dxm-provider,default`
 - **No Blueprint/Spring** — pure OSGi DS
 
@@ -79,7 +79,7 @@ yarn install
 
 ## Security invariants (do not regress) — SECURITY-746
 
-The SSRF and log-injection predicates live in `org.jahia.modules.downloadhelper.util.UrlSecurityUtils`
+The SSRF and log-injection predicates live in `org.jahia.community.downloadhelper.util.UrlSecurityUtils`
 (pure, no DNS/OSGi, fully unit-tested). Do not duplicate them inline — extend the helper instead.
 
 - **No automatic redirect following on the HTTPS download.** `downloadHttps` follows redirects manually

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Jahia OSGi module that lets admins trigger server-side file downloads (HTTPS or 
 ## Key Facts
 
 - **artifactId**: `download-helper` | **version**: `2.0.6-SNAPSHOT`
-- **Java package**: `org.jahia.modules.downloadhelper`
+- **Java package**: `org.jahia.community.downloadhelper`
 - **jahia-depends**: `serverSettings,graphql-dxm-provider,default`
 - **GraphQL API** — admin UI backed by GraphQL mutations/queries gated by `adminDownloadHelper` permission
 - **No Blueprint/Spring** — pure OSGi DS

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <_dsannotations>org.jahia.modules.downloadhelper.*</_dsannotations>
+            <_dsannotations>org.jahia.community.downloadhelper.*</_dsannotations>
           </instructions>
         </configuration>
       </plugin>

--- a/src/main/java/org/jahia/community/downloadhelper/constants/DownloadHelperConstants.java
+++ b/src/main/java/org/jahia/community/downloadhelper/constants/DownloadHelperConstants.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.downloadhelper.constants;
+package org.jahia.community.downloadhelper.constants;
 
 /**
  * Shared, non-instantiable constants for the download-helper module.

--- a/src/main/java/org/jahia/community/downloadhelper/constants/Email.java
+++ b/src/main/java/org/jahia/community/downloadhelper/constants/Email.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.downloadhelper.constants;
+package org.jahia.community.downloadhelper.constants;
 
 public final class Email {
 

--- a/src/main/java/org/jahia/community/downloadhelper/graphql/DownloadHelperGraphQLExtensionsProvider.java
+++ b/src/main/java/org/jahia/community/downloadhelper/graphql/DownloadHelperGraphQLExtensionsProvider.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.downloadhelper.graphql;
+package org.jahia.community.downloadhelper.graphql;
 
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLExtensionsProvider;
 import org.osgi.service.component.annotations.Component;

--- a/src/main/java/org/jahia/community/downloadhelper/graphql/DownloadHelperMutation.java
+++ b/src/main/java/org/jahia/community/downloadhelper/graphql/DownloadHelperMutation.java
@@ -1,10 +1,10 @@
-package org.jahia.modules.downloadhelper.graphql;
+package org.jahia.community.downloadhelper.graphql;
 
 import graphql.annotations.annotationTypes.*;
-import org.jahia.modules.downloadhelper.constants.DownloadHelperConstants;
-import org.jahia.modules.downloadhelper.services.DownloadHelperService;
-import org.jahia.modules.downloadhelper.util.DownloadPaths;
-import org.jahia.modules.downloadhelper.util.UrlSecurityUtils;
+import org.jahia.community.downloadhelper.constants.DownloadHelperConstants;
+import org.jahia.community.downloadhelper.services.DownloadHelperService;
+import org.jahia.community.downloadhelper.util.DownloadPaths;
+import org.jahia.community.downloadhelper.util.UrlSecurityUtils;
 import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 import org.jahia.osgi.BundleUtils;
 import org.jahia.services.content.JCRSessionFactory;

--- a/src/main/java/org/jahia/community/downloadhelper/graphql/DownloadHelperMutationExtension.java
+++ b/src/main/java/org/jahia/community/downloadhelper/graphql/DownloadHelperMutationExtension.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.downloadhelper.graphql;
+package org.jahia.community.downloadhelper.graphql;
 
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;

--- a/src/main/java/org/jahia/community/downloadhelper/graphql/DownloadHelperQuery.java
+++ b/src/main/java/org/jahia/community/downloadhelper/graphql/DownloadHelperQuery.java
@@ -1,11 +1,11 @@
-package org.jahia.modules.downloadhelper.graphql;
+package org.jahia.community.downloadhelper.graphql;
 
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
-import org.jahia.modules.downloadhelper.constants.DownloadHelperConstants;
-import org.jahia.modules.downloadhelper.services.DownloadHelperService;
-import org.jahia.modules.downloadhelper.util.FileSizeUtils;
+import org.jahia.community.downloadhelper.constants.DownloadHelperConstants;
+import org.jahia.community.downloadhelper.services.DownloadHelperService;
+import org.jahia.community.downloadhelper.util.FileSizeUtils;
 import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 import org.jahia.osgi.BundleUtils;
 import org.jahia.services.mail.MailService;

--- a/src/main/java/org/jahia/community/downloadhelper/graphql/DownloadHelperQueryExtension.java
+++ b/src/main/java/org/jahia/community/downloadhelper/graphql/DownloadHelperQueryExtension.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.downloadhelper.graphql;
+package org.jahia.community.downloadhelper.graphql;
 
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;

--- a/src/main/java/org/jahia/community/downloadhelper/graphql/GqlDownloadedFile.java
+++ b/src/main/java/org/jahia/community/downloadhelper/graphql/GqlDownloadedFile.java
@@ -1,9 +1,9 @@
-package org.jahia.modules.downloadhelper.graphql;
+package org.jahia.community.downloadhelper.graphql;
 
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
-import org.jahia.modules.downloadhelper.util.FileSizeUtils;
+import org.jahia.community.downloadhelper.util.FileSizeUtils;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;

--- a/src/main/java/org/jahia/community/downloadhelper/graphql/GqlServerInfo.java
+++ b/src/main/java/org/jahia/community/downloadhelper/graphql/GqlServerInfo.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.downloadhelper.graphql;
+package org.jahia.community.downloadhelper.graphql;
 
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;

--- a/src/main/java/org/jahia/community/downloadhelper/services/DownloadHelperService.java
+++ b/src/main/java/org/jahia/community/downloadhelper/services/DownloadHelperService.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.downloadhelper.services;
+package org.jahia.community.downloadhelper.services;
 
 import org.apache.commons.net.util.Base64;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -8,10 +8,10 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpStatus;
-import org.jahia.modules.downloadhelper.constants.Email;
-import org.jahia.modules.downloadhelper.util.DownloadPaths;
-import org.jahia.modules.downloadhelper.util.FileSizeUtils;
-import org.jahia.modules.downloadhelper.util.UrlSecurityUtils;
+import org.jahia.community.downloadhelper.constants.Email;
+import org.jahia.community.downloadhelper.util.DownloadPaths;
+import org.jahia.community.downloadhelper.util.FileSizeUtils;
+import org.jahia.community.downloadhelper.util.UrlSecurityUtils;
 import org.jahia.services.mail.MailService;
 import org.jahia.services.notification.HttpClientService;
 import org.osgi.service.component.annotations.Activate;
@@ -43,7 +43,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-import static org.jahia.modules.downloadhelper.util.UrlSecurityUtils.sanitizeForLog;
+import static org.jahia.community.downloadhelper.util.UrlSecurityUtils.sanitizeForLog;
 
 @Component(service = DownloadHelperService.class)
 public class DownloadHelperService {

--- a/src/main/java/org/jahia/community/downloadhelper/util/DownloadPaths.java
+++ b/src/main/java/org/jahia/community/downloadhelper/util/DownloadPaths.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.downloadhelper.util;
+package org.jahia.community.downloadhelper.util;
 
 import org.apache.commons.io.FilenameUtils;
 

--- a/src/main/java/org/jahia/community/downloadhelper/util/FileSizeUtils.java
+++ b/src/main/java/org/jahia/community/downloadhelper/util/FileSizeUtils.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.downloadhelper.util;
+package org.jahia.community.downloadhelper.util;
 
 import java.text.DecimalFormat;
 

--- a/src/main/java/org/jahia/community/downloadhelper/util/UrlSecurityUtils.java
+++ b/src/main/java/org/jahia/community/downloadhelper/util/UrlSecurityUtils.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.downloadhelper.util;
+package org.jahia.community.downloadhelper.util;
 
 import org.apache.hc.core5.http.HttpStatus;
 

--- a/src/test/java/org/jahia/community/downloadhelper/services/DownloadHelperServiceTest.java
+++ b/src/test/java/org/jahia/community/downloadhelper/services/DownloadHelperServiceTest.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.downloadhelper.services;
+package org.jahia.community.downloadhelper.services;
 
 import org.jahia.services.mail.MailService;
 import org.jahia.services.notification.HttpClientService;
@@ -172,7 +172,7 @@ class DownloadHelperServiceTest {
             // The exact string value is referenced by RBAC config and Cypress tests; locking it here
             // prevents accidental renames from silently breaking access control.
             org.assertj.core.api.Assertions.assertThat(
-                    org.jahia.modules.downloadhelper.constants.DownloadHelperConstants.PERMISSION)
+                    org.jahia.community.downloadhelper.constants.DownloadHelperConstants.PERMISSION)
                     .isEqualTo("adminDownloadHelper");
         }
     }

--- a/src/test/java/org/jahia/community/downloadhelper/util/DownloadPathsTest.java
+++ b/src/test/java/org/jahia/community/downloadhelper/util/DownloadPathsTest.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.downloadhelper.util;
+package org.jahia.community.downloadhelper.util;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/jahia/community/downloadhelper/util/FileSizeUtilsTest.java
+++ b/src/test/java/org/jahia/community/downloadhelper/util/FileSizeUtilsTest.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.downloadhelper.util;
+package org.jahia.community.downloadhelper.util;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/org/jahia/community/downloadhelper/util/UrlSecurityUtilsTest.java
+++ b/src/test/java/org/jahia/community/downloadhelper/util/UrlSecurityUtilsTest.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.downloadhelper.util;
+package org.jahia.community.downloadhelper.util;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;


### PR DESCRIPTION
## Summary
Renames the module's own base Java package from `org.jahia.modules.downloadhelper` to `org.jahia.community.downloadhelper` (incl. `.constants`, `.services`, `.util`, `.graphql` sub-packages), aligning the namespace with the `org.jahia.community` Maven groupId this community module already uses.

## Changes
- `git mv` of package directories (main + test) — history preserved
- bnd `_dsannotations` scan repointed to the new package
- AGENTS.md / README references updated

## Deliberately unchanged
- Jahia GraphQL provider API imports (`org.jahia.modules.graphql.provider.dxm.*`)
- Parent/dependency Maven `groupId` `org.jahia.modules`

## Verification
- ✅ 112 unit tests pass (JDK17 build)
- ✅ Full Cypress E2E **20/20 pass** on the deployed bundle (01 13/13, 02-Permissions 7/7)